### PR TITLE
Tooltip 컴포넌트 개선

### DIFF
--- a/packages/co-design-core/src/components/Tooltip/Tooltip.style.ts
+++ b/packages/co-design-core/src/components/Tooltip/Tooltip.style.ts
@@ -37,6 +37,8 @@ export default createStyles((theme, { colorScheme }: TooltipStyles) => ({
     backgroundColor: colorScheme === 'dark' ? theme.colors.white : theme.palettes.gray[9],
     userSelect: 'none',
     pointerEvents: 'none',
+    // content 와 별개로 arrow shadow 지정 필요
+    boxShadow: '-2px -2px 3px -1px rgba(0, 0, 0, 0.1)',
 
     '&[class^="top"]': {
       top: -18,
@@ -152,5 +154,11 @@ export default createStyles((theme, { colorScheme }: TooltipStyles) => ({
     '&.left-bottom': {
       transform: 'translateY(-100%)',
     },
+  },
+  title: {
+    fontWeight: 700,
+  },
+  description: {
+    color: colorScheme === 'dark' ? theme.palettes.gray[6] : theme.palettes.gray[3],
   },
 }));

--- a/packages/co-design-core/src/components/Tooltip/Tooltip.style.ts
+++ b/packages/co-design-core/src/components/Tooltip/Tooltip.style.ts
@@ -1,4 +1,8 @@
-import { createStyles, defaultFontStyles } from '@co-design/styles';
+import { ColorScheme, createStyles, defaultFontStyles } from '@co-design/styles';
+
+interface TooltipStyles {
+  colorScheme: ColorScheme;
+}
 
 export type TooltipPlacement =
   | 'top-left'
@@ -16,7 +20,7 @@ export type TooltipPlacement =
 
 export type TooltipTrigger = 'hover' | 'click' | 'focus';
 
-export default createStyles((theme) => ({
+export default createStyles((theme, { colorScheme }: TooltipStyles) => ({
   root: {
     display: 'inline-block',
   },
@@ -30,7 +34,7 @@ export default createStyles((theme) => ({
     position: 'absolute',
     width: 12,
     height: 12,
-    backgroundColor: theme.colorScheme === 'dark' ? theme.colors.white : theme.palettes.gray[8],
+    backgroundColor: colorScheme === 'dark' ? theme.colors.white : theme.palettes.gray[9],
     userSelect: 'none',
     pointerEvents: 'none',
 
@@ -91,10 +95,13 @@ export default createStyles((theme) => ({
     position: 'absolute',
     padding: theme.spacing.small,
     borderRadius: theme.radius.medium,
-    backgroundColor: theme.colorScheme === 'dark' ? theme.colors.white : theme.palettes.gray[8],
+    backgroundColor: colorScheme === 'dark' ? theme.colors.white : theme.palettes.gray[9],
     ...defaultFontStyles(theme),
     fontSize: theme.fontSizes.small,
-    color: theme.colorScheme === 'dark' ? theme.palettes.gray[8] : theme.colors.white,
+    color: colorScheme === 'dark' ? theme.palettes.gray[9] : theme.colors.white,
+
+    // TODO: @co-design/styles 의 shadow token 재정립
+    boxShadow: '0px 0px 4px rgba(0,0,0,0.12), 0px 4px 5px rgba(0,0,0,0.1)',
 
     '&[class^="top"]': {
       bottom: 0,

--- a/packages/co-design-core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/co-design-core/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { ClassNames, CoComponentProps, CoZIndex, useCoTheme } from '@co-design/styles';
+import { ClassNames, CoComponentProps, CoZIndex, ColorScheme, useCoTheme } from '@co-design/styles';
 import { View } from '../View';
 import { Portal } from '../Portal/Portal';
 import { getFieldValue } from '../../utils';
@@ -15,6 +15,9 @@ export interface TooltipProps extends CoComponentProps<TooltipStylesNames>, Reac
    * Tooltip 컴포넌트를 직접 제어할 경우 사용하는 속성입니다.
    */
   visible?: boolean;
+
+  /** Tooltip 컴포넌트의 배경색 지정을 위한 ColorScheme 을 정합니다. */
+  colorScheme?: ColorScheme;
 
   /** Tooltip 컴포넌트가 보여줄 문자열을 정합니다. */
   label: string;
@@ -78,6 +81,7 @@ const getPositionStyle = (placement: TooltipPlacement, target?: HTMLElement) => 
 export const Tooltip = ({
   children,
   visible = false,
+  colorScheme,
   label,
   withArrow = true,
   width,
@@ -95,7 +99,12 @@ export const Tooltip = ({
   ...props
 }: TooltipProps) => {
   const theme = useCoTheme();
-  const { classes, cx } = useStyles(null, { overrideStyles, name: 'Tooltip' });
+  const { classes, cx } = useStyles(
+    {
+      colorScheme: colorScheme || theme.colorScheme,
+    },
+    { overrideStyles, name: 'Tooltip' },
+  );
 
   const [currentVisible, setCurrentVisible] = useToggle(visible);
   const balloonRef = useRef<HTMLDivElement>(null);

--- a/packages/co-design-core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/co-design-core/src/components/Tooltip/Tooltip.tsx
@@ -6,6 +6,7 @@ import { getFieldValue } from '../../utils';
 import useStyles, { TooltipPlacement, TooltipTrigger } from './Tooltip.style';
 import { useClickAway, useToggle, useUpdateEffect } from '@co-design/hooks';
 import { Transition, CoTransition } from '../Transition';
+import { Stack } from '../Stack';
 
 export type TooltipStylesNames = ClassNames<typeof useStyles>;
 
@@ -18,6 +19,9 @@ export interface TooltipProps extends CoComponentProps<TooltipStylesNames>, Reac
 
   /** Tooltip 컴포넌트의 배경색 지정을 위한 ColorScheme 을 정합니다. */
   colorScheme?: ColorScheme;
+
+  /** Tooltip 컴포넌트가 보여줄 제목을 정합니다. */
+  title?: string;
 
   /** Tooltip 컴포넌트가 보여줄 문자열을 정합니다. */
   label: string;
@@ -82,6 +86,7 @@ export const Tooltip = ({
   children,
   visible = false,
   colorScheme,
+  title,
   label,
   withArrow = true,
   width,
@@ -160,7 +165,14 @@ export const Tooltip = ({
           {(styles) => (
             <View className={classes.balloon} style={{ ...positionStyle, ...styles }} ref={balloonRef} {...props}>
               <div className={cx(placement, classes.content)} style={contentStyle}>
-                {label}
+                {title ? (
+                  <Stack spacing="small">
+                    <span className={classes.title}>{title}</span>
+                    <span className={classes.description}>{label}</span>
+                  </Stack>
+                ) : (
+                  label
+                )}
               </div>
               {withArrow && <div className={cx(placement, classes.arrow)} />}
             </View>

--- a/packages/co-design-core/src/components/Tooltip/stories/Tooltip.stories.tsx
+++ b/packages/co-design-core/src/components/Tooltip/stories/Tooltip.stories.tsx
@@ -41,6 +41,10 @@ export default {
       options: [undefined, 'light', 'dark'],
       control: { type: 'inline-radio' },
     },
+    title: {
+      options: [undefined, 'title'],
+      control: { type: 'text' },
+    },
   },
 };
 
@@ -48,6 +52,16 @@ export const Default = (props) => {
   return (
     <Center style={{ width: 500, height: 500 }}>
       <Tooltip placement="bottom" label="Test" {...props}>
+        <button>Tooltip</button>
+      </Tooltip>
+    </Center>
+  );
+};
+
+export const WithTitle = (props) => {
+  return (
+    <Center style={{ width: 500, height: 500 }}>
+      <Tooltip placement="bottom" title="Title" label="Peek-A-Boo" {...props}>
         <button>Tooltip</button>
       </Tooltip>
     </Center>

--- a/packages/co-design-core/src/components/Tooltip/stories/Tooltip.stories.tsx
+++ b/packages/co-design-core/src/components/Tooltip/stories/Tooltip.stories.tsx
@@ -37,6 +37,10 @@ export default {
       options: ['hover', 'click', 'focus'],
       control: { type: 'inline-radio' },
     },
+    colorScheme: {
+      options: [undefined, 'light', 'dark'],
+      control: { type: 'inline-radio' },
+    },
   },
 };
 


### PR DESCRIPTION
## :pushpin: PR 설명
* Tooltip 컴포넌트 사용 시 props 으로 colorScheme 을 지정하여 배경색상을 변경할 수 있도록 개선하였습니다.
* title prop 을 받을 시 title 과 description 으로 나누어진 디자인을 보여줄 수 있도록 기능 추가하였습니다.
* 기존 Tooltip 에는 box-shadow 적용이 되어있지 않아 추가로 적용했습니다.
  - content 와 별개로 arrow 에도 box shadow 를 달아주어야 했는데, 지은님과 의논하여 임의 고정 수치로 임시 지정하였습니다.
* @co-disign/styles 의 shadows 토큰은 현재 디자인 시스템과 달리 사이즈(small, medium..)에 맞추어져 있어 해당 부분 또한 지은님과 의논하여 토큰을 사용하지 않고 임시로 값을 넣었습니다.

