### PR TITLE
Pagination 컴포넌트 추가

### DIFF
--- a/packages/co-design-core/src/components/Pagination/Bullet.tsx
+++ b/packages/co-design-core/src/components/Pagination/Bullet.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface BulletProps {
+  className?: string;
+  circleClassName?: string;
+}
+
+const Bullet = ({ circleClassName, ...props }: BulletProps) => {
+  return (
+    <div {...props}>
+      {[0, 1, 2].map((_, index) => (
+        <div key={index} className={circleClassName} />
+      ))}
+    </div>
+  );
+};
+
+export default Bullet;

--- a/packages/co-design-core/src/components/Pagination/Pagination.style.ts
+++ b/packages/co-design-core/src/components/Pagination/Pagination.style.ts
@@ -1,0 +1,74 @@
+import { createStyles } from '@co-design/styles';
+
+export default createStyles((theme) => ({
+  root: {
+    display: 'inline-flex',
+    alignItems: 'center',
+  },
+  page: {
+    display: 'inline-block',
+    minWidth: '32px',
+    height: '32px',
+    padding: '7px 11.5px',
+    textAlign: 'center',
+    fontSize: '14px',
+    lineHeight: '20px',
+    verticalAlign: 'middle',
+    color: '#171b24',
+    boxSizing: 'border-box',
+    marginRight: '8px',
+    cursor: 'pointer',
+    '@media (max-width: 500px)': {
+      minWidth: '24px',
+      height: '24px',
+      padding: '2px 4px',
+    },
+    '&:last-of-type': {
+      marginRight: '0px',
+    },
+    '&:hover': {
+      backgroundColor: 'rgba(35, 40, 48, 0.12)',
+    },
+  },
+  active: {
+    backgroundColor: theme.palettes.gray[9],
+    color: 'white',
+    '&:hover': {
+      backgroundColor: theme.palettes.gray[9],
+    },
+  },
+  arrow: {
+    display: 'inline-block',
+    width: '32px',
+    height: '32px',
+    verticalAlign: 'middle',
+    '&:first-of-type': {
+      marginRight: '8px',
+    },
+    '&:last-of-type': {
+      marginLeft: '8px',
+    },
+  },
+  disabled: {
+    pointerEvents: 'none',
+    cursor: 'not-allowed',
+  },
+  bullet: {
+    marginRight: '4px',
+    '@media (max-width: 500px)': {
+      width: '24px',
+      height: '24px',
+    },
+  },
+  circle: {
+    display: 'inline-block',
+    width: '3px',
+    height: '3px',
+    borderRadius: '50%',
+    marginRight: '4px',
+    backgroundColor: '#171b24',
+    '&:last-of-type': {
+      marginRight: '0px',
+    },
+  },
+}));

--- a/packages/co-design-core/src/components/Pagination/Pagination.tsx
+++ b/packages/co-design-core/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,144 @@
+import React, { useState, useEffect } from 'react';
+import { View } from '../View';
+import { IconButton } from '../IconButton';
+import ChevronLeft from './icons/ChevronLeft';
+import ChevronRight from './icons/ChevronRight';
+import useStyles from './Pagination.style';
+
+export interface PaginationProps {
+  activePage?: number;
+  itemsCountPerView?: number;
+  totalItemsCount: number;
+  showFirst?: boolean;
+  showLast?: boolean;
+  onChange?(page: number): void;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export const Pagination = ({
+  activePage = 1,
+  itemsCountPerView = 10,
+  totalItemsCount,
+  showFirst = true,
+  showLast = true,
+  onChange,
+  className = '',
+  style,
+  ...props
+}: PaginationProps) => {
+  const [currentPage, setCurrentPage] = useState(activePage);
+  const { cx, classes } = useStyles(null, {
+    name: 'Pagination',
+  });
+
+  const totalPage = Math.ceil(totalItemsCount / itemsCountPerView);
+  let pages = [];
+
+  if (totalPage <= 5) {
+    pages = Array(totalPage)
+      .fill(0)
+      .map((_, index) => index + 1);
+  } else if (currentPage < 3) {
+    pages = [1, 2, 3, 4, 5];
+  } else if (totalPage - 2 < currentPage) {
+    pages = [totalPage - 4, totalPage - 3, totalPage - 2, totalPage - 1, totalPage];
+  } else {
+    pages = [currentPage - 2, currentPage - 1, currentPage, currentPage + 1, currentPage + 2];
+  }
+
+  useEffect(() => {
+    setCurrentPage(activePage);
+  }, [activePage]);
+
+  const handleChangePage = (page: number) => {
+    onChange?.(page);
+    setCurrentPage(page);
+  };
+
+  const handlePrevPage = () => {
+    if (currentPage > 1) {
+      onChange?.(currentPage - 1);
+      setCurrentPage(currentPage - 1);
+    }
+  };
+
+  const handleNextPage = () => {
+    if (currentPage < totalPage) {
+      onChange?.(currentPage + 1);
+      setCurrentPage(currentPage + 1);
+    }
+  };
+
+  const Bullet = () => {
+    return (
+      <div className={classes.bullet}>
+        {[0, 1, 2].map((_, index) => (
+          <div key={index} className={classes.circle} />
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <View className={classes.root} style={style} {...props}>
+      <IconButton
+        color="gray"
+        variant="text"
+        className={cx(classes.arrow, { [classes.disabled]: currentPage === 1 })}
+        onClick={handlePrevPage}
+        overrideStyles={{
+          text: {
+            '&:not(:disabled):hover': {
+              borderRadius: 0,
+            },
+          },
+        }}
+      >
+        <ChevronLeft color={currentPage === 1 ? '#D5DADF' : '#171B24'} />
+      </IconButton>
+
+      {currentPage > 3 && totalPage > pages.length && showFirst ? (
+        <>
+          <div className={cx(classes.page, { [classes.active]: 1 === currentPage })} onClick={() => handleChangePage(1)}>
+            1
+          </div>
+          <Bullet />
+        </>
+      ) : null}
+
+      {pages.map((index) => (
+        <div className={cx(classes.page, { [classes.active]: index === currentPage })} key={index} onClick={() => handleChangePage(index)}>
+          {index}
+        </div>
+      ))}
+
+      {totalPage - 2 > currentPage && totalPage > pages.length && showLast ? (
+        <>
+          <Bullet />
+          <div className={cx(classes.page, { [classes.active]: totalPage === currentPage })} onClick={() => handleChangePage(totalPage)}>
+            {totalPage}
+          </div>
+        </>
+      ) : null}
+
+      <IconButton
+        color="gray"
+        variant="text"
+        className={cx(classes.arrow, { [classes.disabled]: currentPage === totalPage })}
+        onClick={handleNextPage}
+        overrideStyles={{
+          text: {
+            '&:not(:disabled):hover': {
+              borderRadius: 0,
+            },
+          },
+        }}
+      >
+        <ChevronRight color={currentPage === totalPage ? '#D5DADF' : '#171B24'} />
+      </IconButton>
+    </View>
+  );
+};
+
+Pagination.displayName = '@co-design/core/Pagination';

--- a/packages/co-design-core/src/components/Pagination/Pagination.tsx
+++ b/packages/co-design-core/src/components/Pagination/Pagination.tsx
@@ -4,16 +4,28 @@ import { IconButton } from '../IconButton';
 import ChevronLeft from './icons/ChevronLeft';
 import ChevronRight from './icons/ChevronRight';
 import useStyles from './Pagination.style';
+import { ClassNames, CoComponentProps } from '@co-design/styles';
 
-export interface PaginationProps {
+export type PaginationStylesNames = ClassNames<typeof useStyles>;
+
+export interface PaginationProps extends CoComponentProps<PaginationStylesNames>, Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'> {
+  /** Pagination 의 초기 Active Page 를 설정합니다. */
   activePage?: number;
+
+  /** Pagination 의 한 페이지당 보여줄 아이템의 개수를 설정합니다. */
   itemsCountPerView?: number;
+
+  /** Pagination 의 전체 아이템의 개수를 설정합니다. */
   totalItemsCount: number;
+
+  /** 첫 페이지를 유지하여 보여주고 선택할 수 있도록 설정합니다. */
   showFirst?: boolean;
+
+  /** 마지막 페이지를 유지하여 보여주고 선택할 수 있도록 설정합니다. */
   showLast?: boolean;
+
+  /** Pagination 의 페이지를 변경했을 때 발생할 이벤트를 설정합니다. */
   onChange?(page: number): void;
-  className?: string;
-  style?: React.CSSProperties;
 }
 
 export const Pagination = ({
@@ -25,10 +37,13 @@ export const Pagination = ({
   onChange,
   className = '',
   style,
+  co,
+  overrideStyles,
   ...props
 }: PaginationProps) => {
   const [currentPage, setCurrentPage] = useState(activePage);
   const { cx, classes } = useStyles(null, {
+    overrideStyles,
     name: 'Pagination',
   });
 
@@ -81,7 +96,7 @@ export const Pagination = ({
   };
 
   return (
-    <View className={classes.root} style={style} {...props}>
+    <View className={classes.root} style={style} co={co} {...props}>
       <IconButton
         color="gray"
         variant="text"

--- a/packages/co-design-core/src/components/Pagination/Pagination.tsx
+++ b/packages/co-design-core/src/components/Pagination/Pagination.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { View } from '../View';
 import { IconButton } from '../IconButton';
 import ChevronLeft from './icons/ChevronLeft';
 import ChevronRight from './icons/ChevronRight';
 import useStyles from './Pagination.style';
 import { ClassNames, CoComponentProps } from '@co-design/styles';
+import Bullet from './Bullet';
 
 export type PaginationStylesNames = ClassNames<typeof useStyles>;
 
@@ -62,10 +63,6 @@ export const Pagination = ({
     pages = [currentPage - 2, currentPage - 1, currentPage, currentPage + 1, currentPage + 2];
   }
 
-  useEffect(() => {
-    setCurrentPage(activePage);
-  }, [activePage]);
-
   const handleChangePage = (page: number) => {
     onChange?.(page);
     setCurrentPage(page);
@@ -83,16 +80,6 @@ export const Pagination = ({
       onChange?.(currentPage + 1);
       setCurrentPage(currentPage + 1);
     }
-  };
-
-  const Bullet = () => {
-    return (
-      <div className={classes.bullet}>
-        {[0, 1, 2].map((_, index) => (
-          <div key={index} className={classes.circle} />
-        ))}
-      </div>
-    );
   };
 
   return (
@@ -118,7 +105,7 @@ export const Pagination = ({
           <div className={cx(classes.page, { [classes.active]: 1 === currentPage })} onClick={() => handleChangePage(1)}>
             1
           </div>
-          <Bullet />
+          <Bullet className={classes.bullet} circleClassName={classes.circle} />
         </>
       ) : null}
 
@@ -130,7 +117,7 @@ export const Pagination = ({
 
       {totalPage - 2 > currentPage && totalPage > pages.length && showLast ? (
         <>
-          <Bullet />
+          <Bullet className={classes.bullet} circleClassName={classes.circle} />
           <div className={cx(classes.page, { [classes.active]: totalPage === currentPage })} onClick={() => handleChangePage(totalPage)}>
             {totalPage}
           </div>

--- a/packages/co-design-core/src/components/Pagination/icons/ChevronLeft.tsx
+++ b/packages/co-design-core/src/components/Pagination/icons/ChevronLeft.tsx
@@ -1,0 +1,9 @@
+import React, { SVGProps } from 'react';
+
+const ChevronLeft = (props: SVGProps<SVGSVGElement>) => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path fillRule="evenodd" clipRule="evenodd" d="M15.41 16.59L10.83 12L15.41 7.41L14 6L8 12L14 18L15.41 16.59Z" fill="#5D636D" />
+  </svg>
+);
+
+export default ChevronLeft;

--- a/packages/co-design-core/src/components/Pagination/icons/ChevronRight.tsx
+++ b/packages/co-design-core/src/components/Pagination/icons/ChevronRight.tsx
@@ -1,0 +1,14 @@
+import React, { SVGProps } from 'react';
+
+const ChevronRight = (props: SVGProps<SVGSVGElement>) => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M8.58984 16.59L13.1698 12L8.58984 7.41L9.99984 6L15.9998 12L9.99984 18L8.58984 16.59Z"
+      fill="#5D636D"
+    />
+  </svg>
+);
+
+export default ChevronRight;

--- a/packages/co-design-core/src/components/Pagination/index.ts
+++ b/packages/co-design-core/src/components/Pagination/index.ts
@@ -1,0 +1,2 @@
+export { Pagination } from './Pagination';
+export type { PaginationProps } from './Pagination';

--- a/packages/co-design-core/src/components/Pagination/stories/Pagination.stories.tsx
+++ b/packages/co-design-core/src/components/Pagination/stories/Pagination.stories.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Pagination } from '../Pagination';
+import { Meta, StoryObj } from '@storybook/react';
+
+type Story = StoryObj<typeof Pagination>;
+
+export default {
+  title: '@co-design/core/Pagination',
+  component: Pagination,
+  argTypes: {
+    activePage: {
+      control: {
+        type: 'number',
+      },
+    },
+    itemsCountPerView: {
+      control: {
+        type: 'number',
+      },
+    },
+    totalItemsCount: {
+      control: {
+        type: 'number',
+      },
+    },
+    showFirst: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    showLast: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  args: {
+    activePage: 1,
+    itemsCountPerView: 10,
+    totalItemsCount: 120,
+    showFirst: true,
+    showLast: true,
+  },
+} as Meta<typeof Pagination>;
+
+export const Default: Story = {};
+
+export const NoShowBullet: Story = {
+  args: {
+    showFirst: false,
+    showLast: false,
+  },
+};

--- a/packages/co-design-core/src/components/index.ts
+++ b/packages/co-design-core/src/components/index.ts
@@ -28,6 +28,7 @@ export * from './Menu';
 export * from './Modal';
 export * from './NativeSelect';
 export * from './Overlay';
+export * from './Pagination';
 export * from './PanelStack';
 export * from './Paper';
 export * from './Popover';


### PR DESCRIPTION
## :pushpin: PR 설명
* 기존 로직을 유지하면서 Pagination 을 추가하였습니다

## :white_check_mark: 리뷰 포인트
* 불필요한 로직 제거
  * useEffect -> activePage ?
  * 추측으로는 Storybook controls 에서 값 변경 시 리렌더링이 되지 않아 확인을 위해 추가한 것으로 추측되는데 자체 제공하는 새로고침을  통해 prop 변경을 확인하는 게 맞다고 생각하여 제거했습니다
* Pagination 컴포넌트 내부에 Bullet 컴포넌트를 선언하여 사용중인데 리렌더링마다 새로 선언하는 것이 불필요하다 생각하여 분리하였습니다
