### PR TITLE
Popover 의 flag 속성을 추가했다

### DIFF
--- a/packages/co-design-core/src/components/Popover/Popover.tsx
+++ b/packages/co-design-core/src/components/Popover/Popover.tsx
@@ -16,6 +16,12 @@ export interface PopoverProps extends CoComponentProps<PopoverStylesNames>, Omit
    */
   opened?: boolean;
 
+  /**
+   * Popover 의 open 상태를 자식 컴포넌트가 제어할 때 사용합니다.
+   * 만약 자식 컴포넌트에게 제어권을 주고, 강제로 open 상태를 toggle 하고 싶다면 flag 를 사용합니다.
+   */
+  flag?: boolean;
+
   /** Popover 컴포넌트에 포함시킬 요소를 넣습니다. */
   content: React.ReactNode;
 
@@ -84,6 +90,7 @@ const getPositionStyle = (placement: PopoverPlacement, target?: HTMLElement) => 
 export const Popover = ({
   children,
   opened,
+  flag,
   content,
   contentPadding = 'medium',
   withArrow = true,
@@ -115,6 +122,7 @@ export const Popover = ({
       !targetRef.current.contains(e.target as HTMLElement) &&
       !balloonRef.current.contains(e.target as HTMLElement)
     ) {
+      console.log('hhh');
       setCurrentOpened(false);
     }
   });
@@ -133,8 +141,8 @@ export const Popover = ({
   const handleBlur = trigger === 'focus' ? () => setCurrentOpened(false) : undefined;
 
   useUpdateEffect(() => {
-    setCurrentOpened(opened);
-  }, [opened]);
+    setCurrentOpened((prev) => !prev);
+  }, [flag]);
 
   useUpdateEffect(() => {
     if (currentOpened) onOpen?.();

--- a/packages/co-design-core/src/components/Popover/Popover.tsx
+++ b/packages/co-design-core/src/components/Popover/Popover.tsx
@@ -122,7 +122,6 @@ export const Popover = ({
       !targetRef.current.contains(e.target as HTMLElement) &&
       !balloonRef.current.contains(e.target as HTMLElement)
     ) {
-      console.log('hhh');
       setCurrentOpened(false);
     }
   });

--- a/packages/co-design-core/src/components/Popover/stories/Popover.stories.tsx
+++ b/packages/co-design-core/src/components/Popover/stories/Popover.stories.tsx
@@ -3,6 +3,7 @@ import { Modal } from '../../Modal';
 import { Center } from '../../Center';
 import { Popover } from '../Popover';
 import { useToggle } from '@co-design/hooks';
+import { Menu } from '../../Menu';
 
 export default {
   title: '@co-design/core/Popover',
@@ -103,6 +104,50 @@ export const InModal = {
           <button>Popover</button>
         </Popover>
       </Modal>
+    );
+  },
+};
+
+export const OpenByChildren = {
+  render: (props) => {
+    return (
+      <Center style={{ width: 500, height: 500 }}>
+        <Popover placement="bottom" content={<Content />} {...props}>
+          <button>Popover</button>
+        </Popover>
+      </Center>
+    );
+  },
+};
+
+export const OpenByChildrenWithFlag = {
+  render: (props) => {
+    const [flag, toggleFlag] = useToggle(false);
+
+    return (
+      <Center style={{ width: 500, height: 500 }}>
+        <Popover
+          flag={flag}
+          placement="bottom"
+          content={
+            <Menu>
+              <Menu.Item>Not close</Menu.Item>
+              <Menu.Item>Not close</Menu.Item>
+              <Menu.Item
+                onClick={() => {
+                  toggleFlag();
+                }}
+              >
+                If click me, Popover close
+              </Menu.Item>
+              <Menu.Item>Not close</Menu.Item>
+            </Menu>
+          }
+          {...props}
+        >
+          <button>Popover</button>
+        </Popover>
+      </Center>
     );
   },
 };


### PR DESCRIPTION
## :pushpin: PR 설명

현재 Popover 사용법은 
1. opened prop 을 넘겨주어 opened 의 제어권을 바깥에서 사용하거나 
2. children 이 trigger 가 되어 opened 제어권을 Popover 가 갖거나(currentOpened)

opened 가 변함에 따라 useEffect 에서 currentOpened 를 바꿔주고 있으나 opened 값이 있을 시 Transition 에서 사용되는 값은 opened 이기 때문에 currentOpened 가 바뀌어도 큰 의미가 없었습니다.

opened 대신, flag 값을 사용해서 의도한바를 동작하도록 변경했습니다. 자식이 제어권을 가지고 있더라도 flag 가 변경되면 currentOpened 를 변경시키고, Transition 에서는 opened 값이 없을 시 currentOpened 값을 사용하기 때문에 의도한 바를 동작하게 할 수 있게 됩니다.

