### PR TITLE
Input 의 useId 를 react 제공 함수로 변경했다

### DIFF
--- a/packages/co-design-core/src/components/Input/Input.tsx
+++ b/packages/co-design-core/src/components/Input/Input.tsx
@@ -1,9 +1,8 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useId } from 'react';
 import { useCoTheme, CoComponentProps, CoSize, PolymorphicComponentProps, PolymorphicRef, CoRadius, ClassNames } from '@co-design/styles';
 import { View } from '../View';
 import useStyles from './Input.style';
 import { Text, TextProps } from '../Text';
-import { useId } from '@co-design/hooks';
 
 export type InputStylesNames = ClassNames<typeof useStyles>;
 
@@ -111,7 +110,7 @@ export const Input: InputComponent & { displayName?: string } = forwardRef(
     return (
       <Wrapper>
         {label && (
-          <label htmlFor={inputId} className={classes.label}>
+          <label htmlFor={inputId + name} className={classes.label}>
             <Text className={classes.labelText} {...labelTextProps}>
               {label}
             </Text>
@@ -139,7 +138,7 @@ export const Input: InputComponent & { displayName?: string } = forwardRef(
             required={required}
             disabled={disabled}
             style={{ paddingRight: rightSection ? rightSectionWidth : theme.spacing.small }}
-            id={inputId}
+            id={inputId + name}
           />
           {rightSection && (
             <div

--- a/packages/co-design-core/src/components/Input/stories/Input.stories.tsx
+++ b/packages/co-design-core/src/components/Input/stories/Input.stories.tsx
@@ -115,3 +115,13 @@ export const WithLabel = {
     );
   },
 };
+
+export const AutoFocus = {
+  render: (props) => {
+    return (
+      <div style={{ width: 400, padding: 24 }}>
+        <Input autoFocus {...props} />
+      </div>
+    );
+  },
+};

--- a/packages/co-design-core/src/components/Input/stories/Input.stories.tsx
+++ b/packages/co-design-core/src/components/Input/stories/Input.stories.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Tooltip } from '../../Tooltip';
 import { Input } from '../Input';
+import { Modal } from '../../Modal';
 
 export default {
   title: '@co-design/core/Input',
@@ -116,12 +117,25 @@ export const WithLabel = {
   },
 };
 
+// Storybook Context 변경으로 인한 리렌더링으로 focus 풀림
 export const AutoFocus = {
   render: (props) => {
+    const [opened, setOpened] = useState(false);
     return (
-      <div style={{ width: 400, padding: 24 }}>
-        <Input autoFocus {...props} />
-      </div>
+      <>
+        <div style={{ width: 400, padding: 24 }}>
+          <button
+            onClick={() => {
+              setOpened(true);
+            }}
+          >
+            open modal
+          </button>
+        </div>
+        <Modal opened={opened} onClose={() => setOpened(false)}>
+          <Input autoFocus {...props} />
+        </Modal>
+      </>
     );
   },
 };


### PR DESCRIPTION
## :pushpin: PR 설명
* co-design/hooks 에서 제공하고 있는 useId 가 리렌더링을 일으켜 focus 가 풀리는 경우가 있어 react 제공 함수로 변경했습니다.


<img width="1585" alt="스크린샷 2023-10-12 오후 6 51 20" src="https://github.com/cobaltinc/co-design/assets/58503584/d6703aec-7d7b-4bbf-b8d5-2fc8e3cc94cc">

<img width="1215" alt="스크린샷 2023-10-12 오후 6 52 23" src="https://github.com/cobaltinc/co-design/assets/58503584/b539a45b-85ce-4806-b2b1-b411946ce5b3">
