### PR TITLE
Drawer 안에서 이벤트 전파 막히는 것 수정했다

### DIFF
--- a/packages/co-design-core/src/components/Drawer/Drawer.tsx
+++ b/packages/co-design-core/src/components/Drawer/Drawer.tsx
@@ -148,15 +148,8 @@ export const CoDrawer = ({
       }}
     >
       {(transitionStyles) => (
-        <View
-          className={cx(classes.root, { [classes.noOverlay]: noOverlay }, className)}
-          role="dialog"
-          aria-modal
-          onMouseDown={() => !noCloseOnClickOutside && onClose()}
-          {...props}
-        >
+        <View className={cx(classes.root, { [classes.noOverlay]: noOverlay }, className)} role="dialog" aria-modal {...props}>
           <Paper
-            onMouseDown={(event) => event.stopPropagation()}
             className={cx(classes.drawer, className)}
             ref={focusTrapRef}
             style={{ ...transitionStyles.drawer, zIndex: (zIndex in theme.zIndex ? theme.zIndex[zIndex] : zIndex) + 2 }}
@@ -186,6 +179,7 @@ export const CoDrawer = ({
                 opacity={_overlayOpacity}
                 zIndex={zIndex}
                 color={overlayColor || (theme.colorScheme === 'dark' ? theme.palettes.gray[9] : theme.colors.black)}
+                onMouseDown={() => !noCloseOnClickOutside && onClose()}
               />
             </div>
           )}

--- a/packages/co-design-core/src/components/Popover/stories/Popover.stories.tsx
+++ b/packages/co-design-core/src/components/Popover/stories/Popover.stories.tsx
@@ -4,6 +4,8 @@ import { Center } from '../../Center';
 import { Popover } from '../Popover';
 import { useToggle } from '@co-design/hooks';
 import { Menu } from '../../Menu';
+import { Drawer } from '../../Drawer';
+import { Button } from '../../Button';
 
 export default {
   title: '@co-design/core/Popover',
@@ -148,6 +150,29 @@ export const OpenByChildrenWithFlag = {
           <button>Popover</button>
         </Popover>
       </Center>
+    );
+  },
+};
+
+export const InDrawer = {
+  render: (props) => {
+    const [opened, toggleOpened] = useToggle();
+
+    return (
+      <div>
+        <Button onClick={toggleOpened}>Open</Button>
+        <Drawer
+          zIndex={2998}
+          opened={opened}
+          onClose={() => {
+            toggleOpened(false);
+          }}
+        >
+          <Popover zIndex={3001} placement="bottom" content={<Content />} {...props}>
+            <button>Popover</button>
+          </Popover>
+        </Drawer>
+      </div>
     );
   },
 };


### PR DESCRIPTION
## :pushpin: PR 설명
* Drawer 안에서 Popover 를 사용할 때 Popover 의 바깥영역을 클릭할 시 Popover 가 닫혀야 하는데, Drawer 를 감싸고 있는 View 에서 이벤트 전파를 막고있어 Popover 내부의 useClickaway 함수가 제대로 동작하고 있지 않았습니다. 
* Drawer 가 닫히도록 하는 onMouseDown 을 Overlay 로 옮겨 Overlay 영역을 눌렀을 때 Drawer 가 닫히는 기존의 기능을 유지하면서 Drawer 내부 Paper 에서는 이벤트 전파가 되도록 수정했습니다.
