### PR TITLE
Tooltip visible 로직 수정했다

### DIFF
--- a/packages/co-design-core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/co-design-core/src/components/Tooltip/Tooltip.tsx
@@ -12,6 +12,11 @@ export type TooltipStylesNames = ClassNames<typeof useStyles>;
 
 export interface TooltipProps extends CoComponentProps<TooltipStylesNames>, React.ComponentPropsWithoutRef<'div'> {
   /**
+   * Tooltip 의 초기 visible 상태를 설정합니다
+   */
+  initVisible?: boolean;
+
+  /**
    * true일 경우 Tooltip 컴포넌트를 보여줍니다.
    * Tooltip 컴포넌트를 직접 제어할 경우 사용하는 속성입니다.
    */
@@ -84,7 +89,8 @@ const getPositionStyle = (placement: TooltipPlacement, target?: HTMLElement) => 
 
 export const Tooltip = ({
   children,
-  visible = false,
+  visible,
+  initVisible = false,
   colorScheme,
   title,
   label,
@@ -111,7 +117,7 @@ export const Tooltip = ({
     { overrideStyles, name: 'Tooltip' },
   );
 
-  const [currentVisible, setCurrentVisible] = useToggle(visible);
+  const [currentVisible, setCurrentVisible] = useToggle(initVisible);
   const balloonRef = useRef<HTMLDivElement>(null);
   const targetRef = useClickAway<HTMLDivElement>((e: MouseEvent) => {
     if (
@@ -139,13 +145,17 @@ export const Tooltip = ({
   const handleBlur = trigger === 'focus' ? () => setCurrentVisible(false) : undefined;
 
   useUpdateEffect(() => {
+    setCurrentVisible(visible);
+  }, [visible]);
+
+  useUpdateEffect(() => {
     onChangeVisible?.(currentVisible);
   }, [currentVisible]);
 
   const contentStyle: React.CSSProperties = {
     width: width ? width : 'auto',
     whiteSpace: width ? 'normal' : 'nowrap',
-    pointerEvents: visible ? 'all' : 'none',
+    pointerEvents: currentVisible ? 'all' : 'none',
   };
   const positionStyle = getPositionStyle(placement, targetRef.current);
 

--- a/packages/co-design-core/src/components/Tooltip/stories/Tooltip.stories.tsx
+++ b/packages/co-design-core/src/components/Tooltip/stories/Tooltip.stories.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { StoryObj } from '@storybook/react';
 import { Center } from '../../Center';
 import { Tooltip } from '../Tooltip';
+import { Popover } from '../../Popover';
+import { Button } from '../../Button';
+import { Menu } from '../../Menu';
 
 export default {
   title: '@co-design/core/Tooltip',
@@ -63,5 +67,29 @@ export const Default = {};
 export const WithTitle = {
   args: {
     title: 'Title',
+  },
+};
+
+export const WithPopover: StoryObj = {
+  render: (arg) => {
+    const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+    return (
+      <Popover
+        placement="bottom"
+        onOpen={() => setIsPopoverOpen(true)}
+        onClose={() => setIsPopoverOpen(false)}
+        content={
+          <Menu>
+            <Menu.Item>1</Menu.Item>
+            <Menu.Item>2</Menu.Item>
+          </Menu>
+        }
+      >
+        <Tooltip visible={!isPopoverOpen} label="Peek-A-Boo" {...arg}>
+          <Button>hello</Button>
+        </Tooltip>
+      </Popover>
+    );
   },
 };


### PR DESCRIPTION
## :pushpin: PR 설명
* Tooltip 의 visible prop 이 변경되었을 때 visible 을 제어할 수 있는 로직이 없어 추가하였습니다.
* 기존의 visible prop 을 initVisible 로 대체하고, 직접 제어하고싶은 경우 visible prop 을 활용해 제어할 수 있도록 설정하였습니다.
